### PR TITLE
Convert Unix timestamp in the usage limit reached message to be human readable #26

### DIFF
--- a/src/ui-styles.ts
+++ b/src/ui-styles.ts
@@ -1128,7 +1128,7 @@ const styles = `
         margin: 0 -12px;
     }
 
-    .tool-item input[type="checkbox"], 
+    .tool-item input[type="checkbox"],
     .tool-item input[type="radio"] {
         margin: 0;
         margin-top: 2px;
@@ -1514,6 +1514,27 @@ const styles = `
         color: var(--vscode-terminal-ansiGreen);
         background-color: rgba(0, 210, 106, 0.1);
         border-color: var(--vscode-terminal-ansiGreen);
+    }
+
+    /* Timestamp formatting */
+    .timestamp {
+        display: inline-block;
+        background: linear-gradient(135deg, rgba(100, 149, 237, 0.15) 0%, rgba(100, 149, 237, 0.1) 100%);
+        border: 1px solid rgba(100, 149, 237, 0.3);
+        color: #6495ed;
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-family: var(--vscode-editor-font-family);
+        font-size: 0.9em;
+        font-weight: 500;
+        cursor: help;
+        transition: all 0.2s ease;
+    }
+
+    .timestamp:hover {
+        background: linear-gradient(135deg, rgba(100, 149, 237, 0.25) 0%, rgba(100, 149, 237, 0.15) 100%);
+        border-color: rgba(100, 149, 237, 0.5);
+        transform: translateY(-1px);
     }
 
     /* Markdown content styles */

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1966,7 +1966,36 @@ const html = `<!DOCTYPE html>
 		}
 
 		updateStatus('Initializing...', 'disconnected');
-		
+
+		function formatUnixTimestamp(timestamp) {
+			try {
+				// Convert to number if it's a string
+				const ts = typeof timestamp === 'string' ? parseInt(timestamp) : timestamp;
+
+				// Check if it's a valid Unix timestamp (between 1970 and 2100)
+				if (ts < 0 || ts > 4102444800) return null;
+
+				// Convert to milliseconds for JavaScript Date
+				const date = new Date(ts * 1000);
+
+				// Format like Linux date command: "Wed Jun 25 11:10:23 PM MST 2025"
+				const options = {
+					weekday: 'short',
+					month: 'short',
+					day: 'numeric',
+					hour: 'numeric',
+					minute: '2-digit',
+					second: '2-digit',
+					hour12: true,
+					timeZoneName: 'short',
+					year: 'numeric'
+				};
+
+				return date.toLocaleString('en-US', options);
+			} catch (e) {
+				return null;
+			}
+		}
 
 		function parseSimpleMarkdown(markdown) {
 			const lines = markdown.split('\\n');
@@ -1976,6 +2005,14 @@ const html = `<!DOCTYPE html>
 
 			for (let line of lines) {
 				line = line.trim();
+				// Format Unix timestamps before other processing
+				line = line.replace(/\\b(\\d{10})\\b/g, (match, timestamp) => {
+					const formatted = formatUnixTimestamp(timestamp);
+					if (formatted) {
+						return \`<span class="timestamp" title="Unix timestamp: \${timestamp}">\${formatted}</span>\`;
+					}
+					return match;
+				});
 
 				// Bold
 				line = line.replace(/\\*\\*(.*?)\\*\\*/g, '<strong>$1</strong>');


### PR DESCRIPTION
This is a fix for issue #26. It simply takes the timestamp, and formats it to be human readable instead of a Unix timestamp.

Example screenshot:
![Screenshot From 2025-06-25 23-36-43](https://github.com/user-attachments/assets/28850bf3-bbf8-4945-939a-ddc47a15e00e)
