### PR TITLE
feat: add proxy support for Claude connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-chat",
-  "version": "1.0.0",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-chat",
-      "version": "1.0.0",
+      "version": "1.0.5",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-code-chat",
   "displayName": "Claude Code Chat",
   "description": "Beautiful Claude Code Chat Interface for VS Code",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "publisher": "AndrePimenta",
   "author": "Andre Pimenta",
   "repository": {
@@ -185,6 +185,21 @@
           "type": "boolean",
           "default": false,
           "description": "Enable Yolo Mode to skip all permission checks. Use with caution as Claude can execute any command without asking."
+        },
+        "claudeCodeChat.proxy.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable proxy for Claude connections"
+        },
+        "claudeCodeChat.proxy.url": {
+          "type": "string",
+          "default": "",
+          "description": "Proxy URL (e.g., http://proxy.example.com:8080) - will be used for both HTTP_PROXY and HTTPS_PROXY"
+        },
+        "claudeCodeChat.proxy.noProxy": {
+          "type": "string",
+          "default": "",
+          "description": "Comma-separated list of hosts to bypass proxy (optional)"
         }
       }
     }


### PR DESCRIPTION
feat: add proxy support for Claude connections

Enables users behind corporate proxies to use Claude Code Chat by providing
proxy configuration options.

- Add proxy configuration settings (enabled, url, noProxy)
- Pass proxy environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) to Claude process
- Support proxy in both native and WSL modes
- Apply proxy settings to terminal commands (/model, /api, login)
- Bump version to 1.0.5

This allows corporate users to configure their proxy settings in VS Code
and have them automatically applied to all Claude connections.
