### PR TITLE
FEAT: chat panel and claude to be editor aware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-chat",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-chat",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-code-chat",
   "displayName": "Claude Code Chat",
   "description": "Beautiful Claude Code Chat Interface for VS Code",
-  "version": "1.1.0 ",
+  "version": "1.1.0",
   "publisher": "AndrePimenta",
   "author": "Andre Pimenta",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-code-chat",
   "displayName": "Claude Code Chat",
   "description": "Beautiful Claude Code Chat Interface for VS Code",
-  "version": "1.0.4",
+  "version": "1.1.0 ",
   "publisher": "AndrePimenta",
   "author": "Andre Pimenta",
   "repository": {

--- a/src/ui-styles.ts
+++ b/src/ui-styles.ts
@@ -1803,7 +1803,7 @@ const styles = `
         margin: 0 -12px;
     }
 
-    .tool-item input[type="checkbox"], 
+    .tool-item input[type="checkbox"],
     .tool-item input[type="radio"] {
         margin: 0;
         margin-top: 2px;
@@ -2880,10 +2880,8 @@ const styles = `
         font-size: 11px;
         color: var(--vscode-descriptionForeground);
         margin-bottom: 6px;
-        padding: 0 4px;
         font-family: var(--vscode-font-family);
     }
-
 
     .selection-header {
         display: flex;
@@ -2918,6 +2916,6 @@ const styles = `
         overflow-y: auto;
         color: var(--vscode-editor-foreground);
     }
-</style>`
+</style>`;
 
-export default styles
+export default styles;

--- a/src/ui-styles.ts
+++ b/src/ui-styles.ts
@@ -2874,6 +2874,124 @@ const styles = `
         overflow: hidden;
         text-overflow: ellipsis;
     }
+
+    /* Editor context styles */
+    .editor-context {
+        margin: 8px 0;
+        background-color: var(--vscode-input-background);
+        border: 1px solid var(--vscode-input-border);
+        border-radius: 4px;
+        font-size: 12px;
+    }
+
+    .editor-context-content {
+        padding: 0;
+    }
+
+    .editor-context-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 8px 12px;
+        background-color: var(--vscode-badge-background);
+        border-bottom: 1px solid var(--vscode-input-border);
+        font-weight: 500;
+    }
+
+    .editor-context-icon {
+        margin-right: 6px;
+    }
+
+    .editor-context-title {
+        flex: 1;
+        color: var(--vscode-badge-foreground);
+        font-size: 13px;
+    }
+
+    .editor-context-close {
+        background: none;
+        border: none;
+        color: var(--vscode-badge-foreground);
+        cursor: pointer;
+        padding: 2px 4px;
+        border-radius: 2px;
+        font-size: 12px;
+        opacity: 0.7;
+    }
+
+    .editor-context-close:hover {
+        opacity: 1;
+        background-color: var(--vscode-toolbar-hoverBackground);
+    }
+
+    .editor-context-details {
+        padding: 12px;
+    }
+
+    .editor-context-info {
+        margin-bottom: 8px;
+    }
+
+    .editor-context-path {
+        display: block;
+        color: var(--vscode-descriptionForeground);
+        font-family: var(--vscode-font-family);
+        font-size: 11px;
+        margin-bottom: 4px;
+        word-break: break-all;
+    }
+
+    .editor-context-meta {
+        display: flex;
+        gap: 12px;
+        font-size: 11px;
+        color: var(--vscode-descriptionForeground);
+    }
+
+    .dirty-indicator {
+        color: var(--vscode-gitDecoration-modifiedResourceForeground);
+        font-weight: bold;
+    }
+
+    .editor-context-selection {
+        border-top: 1px solid var(--vscode-input-border);
+        padding-top: 8px;
+        margin-top: 8px;
+    }
+
+    .selection-header {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        margin-bottom: 6px;
+        font-size: 11px;
+        color: var(--vscode-foreground);
+    }
+
+    .selection-icon {
+        font-size: 12px;
+    }
+
+    .selection-range {
+        margin-left: auto;
+        color: var(--vscode-descriptionForeground);
+        font-family: monospace;
+    }
+
+    .selection-preview {
+        background-color: var(--vscode-textCodeBlock-background);
+        border: 1px solid var(--vscode-input-border);
+        border-radius: 3px;
+        padding: 8px;
+        font-family: var(--vscode-editor-font-family);
+        font-size: 11px;
+        line-height: 1.4;
+        white-space: pre-wrap;
+        word-break: break-word;
+        max-height: 120px;
+        overflow-y: auto;
+        color: var(--vscode-editor-foreground);
+    }
 </style>`
 
 export default styles

--- a/src/ui-styles.ts
+++ b/src/ui-styles.ts
@@ -2876,88 +2876,14 @@ const styles = `
     }
 
     /* Editor context styles */
-    .editor-context {
-        margin: 8px 0;
-        background-color: var(--vscode-input-background);
-        border: 1px solid var(--vscode-input-border);
-        border-radius: 4px;
-        font-size: 12px;
-    }
-
-    .editor-context-content {
-        padding: 0;
-    }
-
-    .editor-context-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 8px 12px;
-        background-color: var(--vscode-badge-background);
-        border-bottom: 1px solid var(--vscode-input-border);
-        font-weight: 500;
-    }
-
-    .editor-context-icon {
-        margin-right: 6px;
-    }
-
-    .editor-context-title {
-        flex: 1;
-        color: var(--vscode-badge-foreground);
-        font-size: 13px;
-    }
-
-    .editor-context-close {
-        background: none;
-        border: none;
-        color: var(--vscode-badge-foreground);
-        cursor: pointer;
-        padding: 2px 4px;
-        border-radius: 2px;
-        font-size: 12px;
-        opacity: 0.7;
-    }
-
-    .editor-context-close:hover {
-        opacity: 1;
-        background-color: var(--vscode-toolbar-hoverBackground);
-    }
-
-    .editor-context-details {
-        padding: 12px;
-    }
-
-    .editor-context-info {
-        margin-bottom: 8px;
-    }
-
-    .editor-context-path {
-        display: block;
+    .editor-context-line {
+        font-size: 11px;
         color: var(--vscode-descriptionForeground);
+        margin-bottom: 6px;
+        padding: 0 4px;
         font-family: var(--vscode-font-family);
-        font-size: 11px;
-        margin-bottom: 4px;
-        word-break: break-all;
     }
 
-    .editor-context-meta {
-        display: flex;
-        gap: 12px;
-        font-size: 11px;
-        color: var(--vscode-descriptionForeground);
-    }
-
-    .dirty-indicator {
-        color: var(--vscode-gitDecoration-modifiedResourceForeground);
-        font-weight: bold;
-    }
-
-    .editor-context-selection {
-        border-top: 1px solid var(--vscode-input-border);
-        padding-top: 8px;
-        margin-top: 8px;
-    }
 
     .selection-header {
         display: flex;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1475,13 +1475,13 @@ const html = `<!DOCTYPE html>
 			let contextText = 'in ' + contextData.fileName;
 			
 			if (contextData.selection && contextData.selectedText) {
-				// Show selection range
-				const startLine = contextData.selection.start.line;
-				const endLine = contextData.selection.end.line;
+				// Show selection range (convert from 0-based to 1-based)
+				const startLine = contextData.selection.start.line + 1;
+				const endLine = contextData.selection.end.line + 1;
 				contextText += ':' + startLine + '-' + endLine;
 			} else {
-				// Show just cursor position
-				contextText += ':' + contextData.cursorPosition.line;
+				// Show just cursor position (convert from 0-based to 1-based)
+				contextText += ':' + (contextData.cursorPosition.line + 1);
 			}
 			
 			editorContextLine.textContent = contextText;
@@ -1501,13 +1501,13 @@ const html = `<!DOCTYPE html>
 			let contextInfo = 'in ' + currentEditorContext.fileName;
 			
 			if (currentEditorContext.selection && currentEditorContext.selectedText) {
-				// Show selection range
-				const startLine = currentEditorContext.selection.start.line;
-				const endLine = currentEditorContext.selection.end.line;
+				// Show selection range (convert from 0-based to 1-based)
+				const startLine = currentEditorContext.selection.start.line + 1;
+				const endLine = currentEditorContext.selection.end.line + 1;
 				contextInfo += ':' + startLine + '-' + endLine;
 			} else {
-				// Show just cursor position
-				contextInfo += ':' + currentEditorContext.cursorPosition.line;
+				// Show just cursor position (convert from 0-based to 1-based)
+				contextInfo += ':' + (currentEditorContext.cursorPosition.line + 1);
 			}
 			
 			return contextInfo;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -54,6 +54,7 @@ const html = `<!DOCTYPE html>
 		</div>
 		
 		<div class="input-container" id="inputContainer">
+			<div class="editor-context-line" id="editorContextLine" style="display: none;"></div>
 			<div class="input-modes">
 				<div class="mode-toggle">
 					<span onclick="togglePlanMode()">Plan First</span>
@@ -115,18 +116,6 @@ const html = `<!DOCTYPE html>
 								</div>
 							</button>
 						</div>
-					</div>
-				</div>
-			</div>
-			<div class="editor-context" id="editorContext" style="display: none;">
-				<div class="editor-context-content">
-					<div class="editor-context-header">
-						<span class="editor-context-icon">📝</span>
-						<span class="editor-context-title" id="editorContextTitle">No active file</span>
-						<button class="editor-context-close" onclick="hideEditorContext()" title="Hide">✕</button>
-					</div>
-					<div class="editor-context-details" id="editorContextDetails">
-						<!-- Context details will be populated here -->
 					</div>
 				</div>
 			</div>
@@ -1475,55 +1464,33 @@ const html = `<!DOCTYPE html>
 
 		function updateEditorContext(contextData) {
 			currentEditorContext = contextData;
-			const editorContextDiv = document.getElementById('editorContext');
-			const titleElement = document.getElementById('editorContextTitle');
-			const detailsElement = document.getElementById('editorContextDetails');
+			const editorContextLine = document.getElementById('editorContextLine');
 			
 			if (!contextData.hasActiveFile) {
-				editorContextDiv.style.display = 'none';
+				editorContextLine.style.display = 'none';
 				return;
 			}
 			
-			// Update title
-			titleElement.textContent = contextData.fileName + ' (' + contextData.language + ')';
-			
-			// Build details HTML
-			let detailsHTML = 
-				'<div class="editor-context-info">' +
-					'<span class="editor-context-path" title="' + contextData.filePath + '">' + contextData.filePath + '</span>' +
-					'<div class="editor-context-meta">' +
-						'<span>Lines: ' + contextData.totalLines + '</span>' +
-						'<span>Cursor: ' + contextData.cursorPosition.line + ':' + contextData.cursorPosition.character + '</span>' +
-						(contextData.isDirty ? '<span class="dirty-indicator">●</span>' : '') +
-					'</div>' +
-				'</div>';
+			// Build simple context line
+			let contextText = 'in ' + contextData.fileName;
 			
 			if (contextData.selection && contextData.selectedText) {
+				// Show selection range
 				const startLine = contextData.selection.start.line;
 				const endLine = contextData.selection.end.line;
-				const lineCount = endLine - startLine + 1;
-				const selectedLength = contextData.selectedText.length;
-				
-				detailsHTML += 
-					'<div class="editor-context-selection">' +
-						'<div class="selection-header">' +
-							'<span class="selection-icon">📋</span>' +
-							'<span>Selected: ' + lineCount + ' line' + (lineCount > 1 ? 's' : '') + ' (' + selectedLength + ' characters)</span>' +
-							'<span class="selection-range">Lines ' + startLine + '-' + endLine + '</span>' +
-						'</div>' +
-						'<div class="selection-preview">' +
-							contextData.selectedText.substring(0, 200) + (contextData.selectedText.length > 200 ? '...' : '') +
-						'</div>' +
-					'</div>';
+				contextText += ':' + startLine + '-' + endLine;
+			} else {
+				// Show just cursor position
+				contextText += ':' + contextData.cursorPosition.line;
 			}
 			
-			detailsElement.innerHTML = detailsHTML;
-			editorContextDiv.style.display = 'block';
+			editorContextLine.textContent = contextText;
+			editorContextLine.style.display = 'block';
 		}
 		
 		function hideEditorContext() {
-			const editorContextDiv = document.getElementById('editorContext');
-			editorContextDiv.style.display = 'none';
+			const editorContextLine = document.getElementById('editorContextLine');
+			editorContextLine.style.display = 'none';
 		}
 		
 		function getEditorContextInfo() {
@@ -1531,10 +1498,16 @@ const html = `<!DOCTYPE html>
 				return null;
 			}
 			
-			let contextInfo = 'Current file: ' + currentEditorContext.fileName;
+			let contextInfo = 'in ' + currentEditorContext.fileName;
+			
 			if (currentEditorContext.selection && currentEditorContext.selectedText) {
-				const lineCount = currentEditorContext.selection.end.line - currentEditorContext.selection.start.line + 1;
-				contextInfo += '\\nSelected text (' + lineCount + ' lines):\\n' + currentEditorContext.selectedText;
+				// Show selection range
+				const startLine = currentEditorContext.selection.start.line;
+				const endLine = currentEditorContext.selection.end.line;
+				contextInfo += ':' + startLine + '-' + endLine;
+			} else {
+				// Show just cursor position
+				contextInfo += ':' + currentEditorContext.cursorPosition.line;
 			}
 			
 			return contextInfo;


### PR DESCRIPTION
The current implementation of the extension is completely disconnected from the editor area.

This connects the open editor (+ current selection) to the chat context similarly on how the actual Claude Code or Copilot do:
It also adds a little `in {filename}:{selectionStart:selectionEnd}` text above the chat input similarly to how Copilot does.

<img width="584" height="549" alt="Screenshot 2025-07-28 at 18 00 13" src="https://github.com/user-attachments/assets/af96e89a-6b00-4a3a-b049-9c8415468600" />

<img width="566" height="615" alt="Screenshot 2025-07-28 at 18 01 43" src="https://github.com/user-attachments/assets/61310c2b-1e2b-4613-94cc-254eb9cd2ec0" />
