### PR TITLE
Remove maxlength limit for custom command prompt textarea

### DIFF
--- a/src/ui.ts
+++ b/src/ui.ts
@@ -467,7 +467,7 @@ const html = `<!DOCTYPE html>
 						</div>
 						<div class="form-group">
 							<label for="snippetPrompt">Prompt Text:</label>
-							<textarea id="snippetPrompt" placeholder="e.g., Help me fix this bug in my code..." rows="3" maxlength="500"></textarea>
+							<textarea id="snippetPrompt" placeholder="e.g., Help me fix this bug in my code..." rows="3"></textarea>
 						</div>
 						<div class="form-buttons">
 							<button class="btn" onclick="saveCustomSnippet()">Save Command</button>


### PR DESCRIPTION
This fixes issue #86 by removing the maxlength attribute from the custom command prompt textarea in the slash commands modal. Users can now add much longer markdown content when creating custom slash commands, resolving the previous truncation at ~500 characters.