### PR TITLE
Fix argument quoting for Windows in claude command- to fix mcp config…

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -532,7 +532,15 @@ class ClaudeChatProvider {
 		} else {
 			// Use native claude command
 			console.log('Using native Claude command');
-			claudeProcess = cp.spawn('claude', args, {
+			// On Windows with shell:true, we need to properly quote arguments with spaces
+			const quotedArgs = args.map(arg => {
+				// Quote arguments that contain spaces
+				if (arg.includes(' ') && !arg.startsWith('"')) {
+					return `"${arg}"`;
+				}
+				return arg;
+			});
+			claudeProcess = cp.spawn('claude', quotedArgs, {
 				shell: process.platform === 'win32',
 				cwd: cwd,
 				stdio: ['pipe', 'pipe', 'pipe'],


### PR DESCRIPTION
The issue was that when using spawn with shell: true on Windows, arguments    
  containing spaces need to be properly quoted. The extension now quotes any arguments that contain spaces
  before passing them to the spawn command, which should resolve the MCP configuration file path parsing  
  issue.