### PR TITLE
Fix AskUserQuestion UI, stop button, and orphaned conversation recovery

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,6 +134,13 @@ class ClaudeChatProvider {
 		suggestions?: any[];
 		toolUseId: string;
 	}> = new Map();
+	// Pending AskUserQuestion requests from stdio control_request messages
+	private _pendingQuestionRequests: Map<string, {
+		requestId: string;
+		questions: any[];
+		toolUseId: string;
+		input: Record<string, unknown>;
+	}> = new Map();
 	private _currentConversation: Array<{ timestamp: string, messageType: string, data: any }> = [];
 	private _conversationStartTime: string | undefined;
 	private _conversationIndex: Array<{
@@ -147,6 +154,7 @@ class ClaudeChatProvider {
 		lastUserMessage: string
 	}> = [];
 	private _currentClaudeProcess: cp.ChildProcess | undefined;
+	private _processGeneration: number = 0;
 	private _abortController: AbortController | undefined;
 	private _isWslProcess: boolean = false;
 	private _wslDistro: string = 'Ubuntu';
@@ -164,8 +172,9 @@ class ClaudeChatProvider {
 		this._initializeConversations();
 		this._initializeMCPConfig();
 
-		// Load conversation index from workspace state
+		// Load conversation index from workspace state, then recover any orphaned files
 		this._conversationIndex = this._context.workspaceState.get('claude.conversationIndex', []);
+		this._recoverOrphanedConversations();
 
 		// Load saved model preference
 		this._selectedModel = this._context.workspaceState.get('claude.selectedModel', 'default');
@@ -351,7 +360,10 @@ class ClaudeChatProvider {
 				this._createImageFile(message.imageData, message.imageType);
 				return;
 			case 'permissionResponse':
-				this._handlePermissionResponse(message.id, message.approved, message.alwaysAllow);
+				this._handlePermissionResponse(message.id, message.approved, message.alwaysAllow, message.denyAndContinue);
+				return;
+			case 'questionResponse':
+				this._handleQuestionResponse(message.id, message.answers);
 				return;
 			case 'getPermissions':
 				this._sendPermissions();
@@ -487,7 +499,17 @@ class ClaudeChatProvider {
 			actualMessage = thinkingPrompt + thinkingMesssage + actualMessage;
 		}
 
+		// Kill any existing process before starting a new one (prevents ghost double-runs)
+		if (this._currentClaudeProcess) {
+			console.log('Killing existing Claude process before starting new one');
+			await this._killClaudeProcess();
+		}
+
 		this._isProcessing = true;
+
+		// Increment generation counter — used to ignore output from killed processes
+		this._processGeneration++;
+		const thisGeneration = this._processGeneration;
 
 		// Clear draft message since we're sending it
 		this._draftMessage = '';
@@ -617,6 +639,23 @@ class ClaudeChatProvider {
 		// Store process reference for potential termination
 		this._currentClaudeProcess = claudeProcess;
 
+		// Handle stream errors gracefully to prevent "Stream closed" crashes
+		if (claudeProcess.stdin) {
+			claudeProcess.stdin.on('error', (err) => {
+				console.log('Claude stdin error (expected during stop):', err.message);
+			});
+		}
+		if (claudeProcess.stdout) {
+			claudeProcess.stdout.on('error', (err) => {
+				console.log('Claude stdout error (expected during stop):', err.message);
+			});
+		}
+		if (claudeProcess.stderr) {
+			claudeProcess.stderr.on('error', (err) => {
+				console.log('Claude stderr error (expected during stop):', err.message);
+			});
+		}
+
 		// Send the message to Claude's stdin as JSON (stream-json input format)
 		// Don't end stdin yet - we need to keep it open for permission responses
 		if (claudeProcess.stdin) {
@@ -650,6 +689,11 @@ class ClaudeChatProvider {
 
 		if (claudeProcess.stdout) {
 			claudeProcess.stdout.on('data', (data) => {
+				// Ignore output from killed/old processes
+				if (!this._currentClaudeProcess || thisGeneration !== this._processGeneration) {
+					return;
+				}
+
 				rawOutput += data.toString();
 
 				// Process JSON stream line by line
@@ -657,6 +701,11 @@ class ClaudeChatProvider {
 				rawOutput = lines.pop() || ''; // Keep incomplete line for next chunk
 
 				for (const line of lines) {
+					// Check again in case stop was called while processing lines
+					if (!this._currentClaudeProcess || thisGeneration !== this._processGeneration) {
+						return;
+					}
+
 					if (line.trim()) {
 						try {
 							const jsonData = JSON.parse(line.trim());
@@ -701,15 +750,18 @@ class ClaudeChatProvider {
 			console.log('Claude process closed with code:', code);
 			console.log('Claude stderr output:', errorOutput);
 
-			if (!this._currentClaudeProcess) {
+			// Always cancel pending permission requests when process closes
+			// Do this before the early return check so permissions are cleaned up
+			// even when stop button was clicked (which clears _currentClaudeProcess first)
+			this._cancelPendingPermissionRequests();
+
+			// Ignore close events from old/killed processes
+			if (!this._currentClaudeProcess || thisGeneration !== this._processGeneration) {
 				return;
 			}
 
 			// Clear process reference
 			this._currentClaudeProcess = undefined;
-
-			// Cancel any pending permission requests (process is gone)
-			this._cancelPendingPermissionRequests();
 
 			// Clear loading indicator and set processing to false
 			this._postMessage({
@@ -737,15 +789,18 @@ class ClaudeChatProvider {
 		claudeProcess.on('error', (error) => {
 			console.log('Claude process error:', error.message);
 
-			if (!this._currentClaudeProcess) {
+			// Always cancel pending permission requests on error
+			// Do this before the early return check so permissions are cleaned up
+			// even when stop button was clicked (which clears _currentClaudeProcess first)
+			this._cancelPendingPermissionRequests();
+
+			// Ignore error events from old/killed processes
+			if (!this._currentClaudeProcess || thisGeneration !== this._processGeneration) {
 				return;
 			}
 
 			// Clear process reference
 			this._currentClaudeProcess = undefined;
-
-			// Cancel any pending permission requests (process is gone)
-			this._cancelPendingPermissionRequests();
 
 			this._postMessage({
 				type: 'clearLoading'
@@ -1488,18 +1543,31 @@ class ClaudeChatProvider {
 		const request = controlRequest.request;
 		const requestId = controlRequest.request_id;
 
-		// Only handle can_use_tool requests (permission requests)
+		// Check if this is an AskUserQuestion request
+		const input = request?.input || {};
 		if (request?.subtype !== 'can_use_tool') {
-			console.log('Ignoring non-permission control request:', request?.subtype);
+			// Check if this looks like an AskUserQuestion (has questions array in input, or tool_name matches)
+			if (input.questions || request?.tool_name === 'AskUserQuestion') {
+				console.log('AskUserQuestion control request received, requestId:', requestId);
+				this._handleAskUserQuestion(requestId, request);
+				return;
+			}
+			console.log('Ignoring unknown control request subtype:', request?.subtype, JSON.stringify(controlRequest).substring(0, 500));
 			return;
 		}
 
 		const toolName = request.tool_name || 'Unknown Tool';
-		const input = request.input || {};
 		const suggestions = request.permission_suggestions;
 		const toolUseId = request.tool_use_id;
 
 		console.log(`Permission request for tool: ${toolName}, requestId: ${requestId}`);
+
+		// Intercept AskUserQuestion — show interactive question UI instead of permission dialog
+		if (toolName === 'AskUserQuestion' && input.questions) {
+			console.log('Intercepting AskUserQuestion as interactive question UI, requestId:', requestId);
+			this._handleAskUserQuestion(requestId, request);
+			return;
+		}
 
 		// Check if this tool is pre-approved
 		const isPreApproved = await this._isToolPreApproved(toolName, input);
@@ -1549,6 +1617,104 @@ class ClaudeChatProvider {
 	}
 
 	/**
+	 * Handle AskUserQuestion control_request from Claude CLI
+	 */
+	private _handleAskUserQuestion(requestId: string, request: any): void {
+		const input = request.input || {};
+		const questions = input.questions || [];
+		const toolUseId = request.tool_use_id;
+
+		// Store the request so we can respond later
+		this._pendingQuestionRequests.set(requestId, {
+			requestId,
+			questions,
+			toolUseId,
+			input
+		});
+
+		// Send question to the webview UI
+		this._sendAndSaveMessage({
+			type: 'userQuestion',
+			data: {
+				id: requestId,
+				questions: questions,
+				status: 'pending'
+			}
+		});
+	}
+
+	/**
+	 * Send AskUserQuestion response back to Claude CLI via stdin
+	 * Uses the same control_response format as permissions, with answers in updatedInput
+	 */
+	private _sendQuestionResponse(requestId: string, answers: any, pendingRequest: any): void {
+		if (!this._currentClaudeProcess?.stdin || this._currentClaudeProcess.stdin.destroyed) {
+			console.error('Cannot send question response: stdin not available');
+			return;
+		}
+
+		// Format answers as a flat map that Claude CLI can serialize cleanly
+		// The tool result format is: "User has answered your questions: key=value"
+		// So we build a simple object with question text -> selected option(s)
+		const formattedAnswers: Record<string, string> = {};
+		const questions = pendingRequest.questions || [];
+		if (Array.isArray(answers)) {
+			for (const answer of answers) {
+				const qi = answer.questionIndex || 0;
+				const question = questions[qi];
+				const key = question?.question || `Question ${qi + 1}`;
+				const selected = answer.selectedOptions || [];
+				formattedAnswers[key] = selected.join(', ') || answer.otherText || '(no selection)';
+			}
+		}
+
+		const updatedInput = { ...pendingRequest.input, answers: formattedAnswers };
+
+		const response = {
+			type: 'control_response',
+			response: {
+				subtype: 'success',
+				request_id: requestId,
+				response: {
+					behavior: 'allow',
+					updatedInput: updatedInput,
+					toolUseID: pendingRequest.toolUseId
+				}
+			}
+		};
+
+		const responseJson = JSON.stringify(response) + '\n';
+		console.log('Sending question response:', responseJson);
+		this._currentClaudeProcess.stdin.write(responseJson);
+	}
+
+	/**
+	 * Handle question response from webview UI
+	 */
+	private _handleQuestionResponse(id: string, answers: any): void {
+		const pendingRequest = this._pendingQuestionRequests.get(id);
+		if (!pendingRequest) {
+			console.error('No pending question request found for id:', id);
+			return;
+		}
+
+		// Remove from pending requests
+		this._pendingQuestionRequests.delete(id);
+
+		// Send the response to Claude via stdin
+		this._sendQuestionResponse(id, answers, pendingRequest);
+
+		// Update the question status in UI
+		this._postMessage({
+			type: 'updateQuestionStatus',
+			data: {
+				id: id,
+				status: 'answered'
+			}
+		});
+	}
+
+	/**
 	 * Send permission response back to Claude CLI via stdin
 	 */
 	private _sendPermissionResponse(
@@ -1561,7 +1727,8 @@ class ClaudeChatProvider {
 			suggestions?: any[];
 			toolUseId: string;
 		},
-		alwaysAllow?: boolean
+		alwaysAllow?: boolean,
+		denyAndContinue?: boolean
 	): void {
 		if (!this._currentClaudeProcess?.stdin || this._currentClaudeProcess.stdin.destroyed) {
 			console.error('Cannot send permission response: stdin not available');
@@ -1585,6 +1752,11 @@ class ClaudeChatProvider {
 				}
 			};
 		} else {
+			// Different message based on whether user wants Claude to continue or not
+			const denyMessage = denyAndContinue
+				? 'User denied permission. Continue without this tool and try a different approach or skip this step.'
+				: 'User denied permission';
+
 			response = {
 				type: 'control_response',
 				response: {
@@ -1592,8 +1764,7 @@ class ClaudeChatProvider {
 					request_id: requestId,
 					response: {
 						behavior: 'deny',
-						message: 'User denied permission',
-						interrupt: true,
+						message: denyMessage,
 						toolUseID: pendingRequest.toolUseId
 					}
 				}
@@ -1602,7 +1773,7 @@ class ClaudeChatProvider {
 
 		const responseJson = JSON.stringify(response) + '\n';
 		console.log('Sending permission response:', responseJson);
-		console.log('Always allow:', alwaysAllow, 'Suggestions included:', !!pendingRequest.suggestions);
+		console.log('Always allow:', alwaysAllow, 'Deny and continue:', denyAndContinue, 'Suggestions included:', !!pendingRequest.suggestions);
 		this._currentClaudeProcess.stdin.write(responseJson);
 	}
 
@@ -1615,7 +1786,7 @@ class ClaudeChatProvider {
 	 * Handle permission response from webview UI
 	 * Sends control_response back to Claude CLI via stdin
 	 */
-	private _handlePermissionResponse(id: string, approved: boolean, alwaysAllow?: boolean): void {
+	private _handlePermissionResponse(id: string, approved: boolean, alwaysAllow?: boolean, denyAndContinue?: boolean): void {
 		const pendingRequest = this._pendingPermissionRequests.get(id);
 		if (!pendingRequest) {
 			console.error('No pending permission request found for id:', id);
@@ -1626,7 +1797,7 @@ class ClaudeChatProvider {
 		this._pendingPermissionRequests.delete(id);
 
 		// Send the response to Claude via stdin
-		this._sendPermissionResponse(id, approved, pendingRequest, alwaysAllow);
+		this._sendPermissionResponse(id, approved, pendingRequest, alwaysAllow, denyAndContinue);
 
 		// Update the permission request status in UI
 		this._postMessage({
@@ -1657,6 +1828,18 @@ class ClaudeChatProvider {
 			});
 		}
 		this._pendingPermissionRequests.clear();
+
+		// Also cancel pending question requests
+		for (const [id, _request] of this._pendingQuestionRequests) {
+			this._postMessage({
+				type: 'updateQuestionStatus',
+				data: {
+					id: id,
+					status: 'cancelled'
+				}
+			});
+		}
+		this._pendingQuestionRequests.clear();
 	}
 
 	/**
@@ -2369,23 +2552,36 @@ class ClaudeChatProvider {
 		const processToKill = this._currentClaudeProcess;
 		const pid = processToKill?.pid;
 
-		// 1. Abort via controller (clean API)
-		this._abortController?.abort();
-		this._abortController = undefined;
-
-		// 2. Clear reference immediately
+		// Clear reference immediately to prevent double-kill and ghost output
 		this._currentClaudeProcess = undefined;
 
 		if (!pid) {
+			this._abortController?.abort();
+			this._abortController = undefined;
 			return;
 		}
 
 		console.log(`Terminating Claude process group (PID: ${pid})...`);
 
-		// 3. Kill process group (handles children)
+		// 1. Close stdin first — graceful shutdown signal (like Ctrl+D)
+		try {
+			if (processToKill?.stdin && !processToKill.stdin.destroyed) {
+				processToKill.stdin.end();
+			}
+		} catch {
+			// stdin may already be closed
+		}
+
+		// 2. Kill process tree BEFORE abort — on Windows with shell:true,
+		// abort() kills cmd.exe which orphans the actual node/claude child.
+		// taskkill /t needs the tree intact to find children.
 		await this._killProcessGroup(pid, 'SIGTERM');
 
-		// 4. Wait for process to exit, with timeout
+		// 3. Now abort via controller (backup, also cancels any pending signal listeners)
+		this._abortController?.abort();
+		this._abortController = undefined;
+
+		// 4. Wait for process to exit, with short timeout
 		const exitPromise = new Promise<void>((resolve) => {
 			if (processToKill?.killed) {
 				resolve();
@@ -2404,6 +2600,15 @@ class ClaudeChatProvider {
 		if (processToKill && !processToKill.killed) {
 			console.log(`Force killing Claude process group (PID: ${pid})...`);
 			await this._killProcessGroup(pid, 'SIGKILL');
+
+			// On Windows, also try to kill any orphaned claude/node child processes
+			if (process.platform === 'win32' && !this._isWslProcess) {
+				try {
+					await exec(`wmic process where "ParentProcessId=${pid}" delete`);
+				} catch {
+					// Children may already be dead
+				}
+			}
 		}
 
 		console.log('Claude process group terminated');
@@ -2419,6 +2624,10 @@ class ClaudeChatProvider {
 			type: 'setProcessing',
 			data: { isProcessing: false }
 		});
+
+		// Cancel pending permission requests immediately (before killing process)
+		// This ensures permissions are cleared even if close event handler returns early
+		this._cancelPendingPermissionRequests();
 
 		await this._killClaudeProcess();
 
@@ -2468,6 +2677,44 @@ class ClaudeChatProvider {
 
 	private _getLatestConversation(): any | undefined {
 		return this._conversationIndex.length > 0 ? this._conversationIndex[0] : undefined;
+	}
+
+	/**
+	 * Scan conversations directory for files not in the index and re-add them.
+	 * Recovers orphaned conversations whose index entries were lost.
+	 */
+	private async _recoverOrphanedConversations(): Promise<void> {
+		if (!this._conversationsPath) { return; }
+
+		try {
+			const dirUri = vscode.Uri.file(this._conversationsPath);
+			const entries = await vscode.workspace.fs.readDirectory(dirUri);
+			const indexedFilenames = new Set(this._conversationIndex.map(e => e.filename));
+			let recovered = 0;
+
+			for (const [name, type] of entries) {
+				if (type !== vscode.FileType.File || !name.endsWith('.json')) { continue; }
+				if (indexedFilenames.has(name)) { continue; }
+
+				// Orphaned file — read it and rebuild the index entry
+				try {
+					const filePath = path.join(this._conversationsPath, name);
+					const content = await vscode.workspace.fs.readFile(vscode.Uri.file(filePath));
+					const conversationData = JSON.parse(new TextDecoder().decode(content));
+					this._updateConversationIndex(name, conversationData);
+					recovered++;
+					console.log(`Recovered orphaned conversation: ${name}`);
+				} catch {
+					// Skip files that can't be parsed
+				}
+			}
+
+			if (recovered > 0) {
+				console.log(`Recovered ${recovered} orphaned conversation(s)`);
+			}
+		} catch {
+			// Conversations directory may not exist yet
+		}
 	}
 
 	private async _loadConversationHistory(filename: string): Promise<void> {

--- a/src/script.ts
+++ b/src/script.ts
@@ -2369,6 +2369,12 @@ const getScript = (isTelemetryEnabled: boolean) => `<script>
 				case 'updatePermissionStatus':
 					updatePermissionStatus(message.data.id, message.data.status);
 					break;
+				case 'userQuestion':
+					addUserQuestionMessage(message.data);
+					break;
+				case 'updateQuestionStatus':
+					updateQuestionStatus(message.data.id, message.data.status);
+					break;
 				case 'expirePendingPermissions':
 					expireAllPendingPermissions();
 					break;
@@ -2438,6 +2444,7 @@ const getScript = (isTelemetryEnabled: boolean) => `<script>
 						<p>Allow <strong>\${toolName}</strong> to execute the tool call above?</p>
 						<div class="permission-buttons">
 							<button class="btn deny" onclick="respondToPermission('\${data.id}', false)">Deny</button>
+							<button class="btn deny-continue" onclick="respondToPermission('\${data.id}', false, false, true)">Deny &amp; Continue</button>
 							<button class="btn always-allow" onclick="respondToPermission('\${data.id}', true, true)" \${alwaysAllowTooltip}>\${alwaysAllowText}</button>
 							<button class="btn allow" onclick="respondToPermission('\${data.id}', true)">Allow</button>
 						</div>
@@ -2530,38 +2537,61 @@ const getScript = (isTelemetryEnabled: boolean) => `<script>
 			});
 		}
 		
-		function respondToPermission(id, approved, alwaysAllow = false) {
+		function respondToPermission(id, approved, alwaysAllow = false, denyAndContinue = false) {
 			// Send response back to extension
 			vscode.postMessage({
 				type: 'permissionResponse',
 				id: id,
 				approved: approved,
-				alwaysAllow: alwaysAllow
+				alwaysAllow: alwaysAllow,
+				denyAndContinue: denyAndContinue
 			});
-			
+
 			// Update the UI to show the decision
 			const permissionMsg = document.querySelector(\`.permission-request:has([onclick*="\${id}"])\`);
 			if (permissionMsg) {
 				const buttons = permissionMsg.querySelector('.permission-buttons');
 				const permissionContent = permissionMsg.querySelector('.permission-content');
 				let decision = approved ? 'You allowed this' : 'You denied this';
-				
+
 				if (alwaysAllow && approved) {
 					decision = 'You allowed this and set it to always allow';
+				} else if (denyAndContinue) {
+					decision = 'You denied this (Claude will continue without it)';
 				}
-				
+
 				const emoji = approved ? '✅' : '❌';
 				const decisionClass = approved ? 'allowed' : 'denied';
-				
-				// Hide buttons
-				buttons.style.display = 'none';
-				
+
+				// For regular deny (not deny & continue), keep Allow button visible so user can change mind
+				if (!approved && !denyAndContinue) {
+					// Hide all buttons except Allow
+					const denyBtn = buttons.querySelector('.btn.deny');
+					const denyContinueBtn = buttons.querySelector('.btn.deny-continue');
+					const alwaysAllowBtn = buttons.querySelector('.btn.always-allow');
+					if (denyBtn) denyBtn.style.display = 'none';
+					if (denyContinueBtn) denyContinueBtn.style.display = 'none';
+					if (alwaysAllowBtn) alwaysAllowBtn.style.display = 'none';
+
+					// Add "Changed your mind?" text before Allow button
+					const allowBtn = buttons.querySelector('.btn.allow');
+					if (allowBtn && !buttons.querySelector('.change-mind-text')) {
+						const changeMindText = document.createElement('span');
+						changeMindText.className = 'change-mind-text';
+						changeMindText.textContent = 'Changed your mind?';
+						buttons.insertBefore(changeMindText, allowBtn);
+					}
+				} else {
+					// Hide all buttons for approve or deny & continue
+					buttons.style.display = 'none';
+				}
+
 				// Add decision div to permission-content
 				const decisionDiv = document.createElement('div');
 				decisionDiv.className = \`permission-decision \${decisionClass}\`;
 				decisionDiv.innerHTML = \`\${emoji} \${decision}\`;
 				permissionContent.appendChild(decisionDiv);
-				
+
 				permissionMsg.classList.add('permission-decided', decisionClass);
 			}
 		}
@@ -2595,6 +2625,131 @@ const getScript = (isTelemetryEnabled: boolean) => `<script>
 			
 			// Show notification
 			addMessage('⚡ YOLO Mode enabled! All future permissions will be automatically allowed.', 'system');
+		}
+
+		// User Question functions
+		function addUserQuestionMessage(data) {
+			const messagesDiv = document.getElementById('messages');
+			const shouldScroll = shouldAutoScroll(messagesDiv);
+
+			const messageDiv = document.createElement('div');
+			messageDiv.className = 'message user-question';
+			messageDiv.id = \`question-\${data.id}\`;
+			messageDiv.dataset.status = data.status || 'pending';
+
+			let contentHtml = \`<div class="question-header"><span class="icon">&#10067;</span><span>Claude has a question</span></div>\`;
+
+			if (data.questions && data.questions.length > 0) {
+				for (let qi = 0; qi < data.questions.length; qi++) {
+					const q = data.questions[qi];
+					const inputType = q.multiSelect ? 'checkbox' : 'radio';
+					const groupName = \`question-\${data.id}-\${qi}\`;
+
+					contentHtml += \`<div class="question-item">\`;
+
+					if (q.header) {
+						contentHtml += \`<span class="header-chip">\${escapeHtml(q.header)}</span> \`;
+					}
+					contentHtml += \`<div class="question-text">\${escapeHtml(q.question)}</div>\`;
+
+					if (q.options && q.options.length > 0) {
+						contentHtml += \`<div class="question-options">\`;
+						for (let oi = 0; oi < q.options.length; oi++) {
+							const opt = q.options[oi];
+							contentHtml += \`
+								<label class="question-option" onclick="this.querySelector('input').checked = true; this.closest('.question-options').querySelectorAll('.question-option').forEach(o => o.classList.remove('selected')); this.classList.add('selected');">
+									<input type="\${inputType}" name="\${groupName}" value="\${escapeHtml(opt.label)}" \${inputType === 'checkbox' ? \`onclick="event.stopPropagation(); this.closest('.question-option').classList.toggle('selected', this.checked);"\` : ''}>
+									<div class="option-content">
+										<span class="option-label">\${escapeHtml(opt.label)}</span>
+										\${opt.description ? \`<span class="option-description">\${escapeHtml(opt.description)}</span>\` : ''}
+									</div>
+								</label>\`;
+						}
+						// "Other" option
+						contentHtml += \`
+							<label class="question-option" onclick="var r = this.querySelector('input[type=&quot;\${inputType}&quot;]'); r.checked = true; if ('\${inputType}' === 'radio') { this.closest('.question-options').querySelectorAll('.question-option').forEach(o => o.classList.remove('selected')); } this.classList.add('selected'); var ti = this.querySelector('.other-text-input'); ti.style.display = 'block'; ti.focus();">
+								<input type="\${inputType}" name="\${groupName}" value="__other__" \${inputType === 'checkbox' ? \`onclick="event.stopPropagation(); this.closest('.question-option').classList.toggle('selected', this.checked); this.closest('.question-option').querySelector('.other-text-input').style.display = this.checked ? 'block' : 'none';"\` : ''}>
+								<div class="option-content">
+									<span class="option-label">Other</span>
+									<input type="text" class="other-text-input" placeholder="Type your answer..." onclick="event.stopPropagation();">
+								</div>
+							</label>\`;
+						contentHtml += \`</div>\`;
+					}
+
+					contentHtml += \`</div>\`;
+				}
+
+				contentHtml += \`<div class="question-buttons"><button class="btn" onclick="submitQuestionResponse('\${data.id}', \${data.questions.length})">Submit</button></div>\`;
+			}
+
+			messageDiv.innerHTML = contentHtml;
+			messagesDiv.appendChild(messageDiv);
+			moveProcessingIndicatorToLast();
+			scrollToBottomIfNeeded(messagesDiv, shouldScroll);
+		}
+
+		function submitQuestionResponse(questionId, questionCount) {
+			const questionDiv = document.getElementById(\`question-\${questionId}\`);
+			if (!questionDiv) return;
+
+			const answers = [];
+			for (let qi = 0; qi < questionCount; qi++) {
+				const groupName = \`question-\${questionId}-\${qi}\`;
+				const checked = questionDiv.querySelectorAll(\`input[name="\${groupName}"]:checked\`);
+				const selectedOptions = [];
+				let otherText = '';
+
+				checked.forEach(function(input) {
+					if (input.value === '__other__') {
+						const textInput = input.closest('.question-option').querySelector('.other-text-input');
+						otherText = textInput ? textInput.value : '';
+						if (otherText) selectedOptions.push(otherText);
+					} else {
+						selectedOptions.push(input.value);
+					}
+				});
+
+				answers.push({
+					questionIndex: qi,
+					selectedOptions: selectedOptions,
+					otherText: otherText
+				});
+			}
+
+			vscode.postMessage({
+				type: 'questionResponse',
+				id: questionId,
+				answers: answers
+			});
+
+			// Update UI to show answered state
+			updateQuestionStatus(questionId, 'answered');
+		}
+
+		function updateQuestionStatus(id, status) {
+			const questionMsg = document.getElementById(\`question-\${id}\`);
+			if (!questionMsg) return;
+
+			questionMsg.dataset.status = status;
+			const buttons = questionMsg.querySelector('.question-buttons');
+			if (buttons) buttons.style.display = 'none';
+
+			// Remove existing decision div
+			const existing = questionMsg.querySelector('.question-decision');
+			if (existing) existing.remove();
+
+			const decisionDiv = document.createElement('div');
+			if (status === 'answered') {
+				decisionDiv.className = 'question-decision answered';
+				decisionDiv.innerHTML = '&#9989; Response submitted';
+				questionMsg.classList.add('question-decided');
+			} else if (status === 'cancelled') {
+				decisionDiv.className = 'question-decision cancelled';
+				decisionDiv.innerHTML = '&#9203; This question expired';
+				questionMsg.classList.add('question-decided');
+			}
+			questionMsg.appendChild(decisionDiv);
 		}
 
 		// Close permission menus when clicking outside

--- a/src/ui-styles.ts
+++ b/src/ui-styles.ts
@@ -258,6 +258,24 @@ const styles = `
         border-color: var(--vscode-focusBorder);
     }
 
+    .permission-buttons .btn.deny-continue {
+        background-color: transparent;
+        color: var(--vscode-foreground);
+        border-color: var(--vscode-panel-border);
+    }
+
+    .permission-buttons .btn.deny-continue:hover {
+        background-color: var(--vscode-list-hoverBackground);
+        border-color: var(--vscode-focusBorder);
+    }
+
+    .permission-buttons .change-mind-text {
+        color: var(--vscode-descriptionForeground);
+        font-size: 12px;
+        margin-right: 8px;
+        font-style: italic;
+    }
+
     .permission-buttons .btn.always-allow {
         background-color: rgba(0, 122, 204, 0.1);
         color: var(--vscode-charts-blue);
@@ -336,6 +354,176 @@ const styles = `
     .permission-decided.expired {
         border-color: var(--vscode-panel-border);
         background-color: rgba(128, 128, 128, 0.05);
+    }
+
+    /* User Question UI */
+    .user-question {
+        margin: 4px 12px 20px 12px;
+        background-color: rgba(100, 100, 255, 0.08);
+        border: 1px solid rgba(100, 100, 255, 0.25);
+        border-radius: 8px;
+        padding: 16px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        animation: slideUp 0.3s ease;
+    }
+
+    .question-header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 12px;
+        font-weight: 600;
+        color: var(--vscode-foreground);
+        font-size: 13px;
+    }
+
+    .question-header .icon {
+        font-size: 16px;
+    }
+
+    .question-header .header-chip {
+        background-color: rgba(100, 100, 255, 0.15);
+        color: var(--vscode-foreground);
+        padding: 2px 8px;
+        border-radius: 4px;
+        font-size: 11px;
+        font-weight: 500;
+    }
+
+    .question-item {
+        margin-bottom: 16px;
+    }
+
+    .question-item:last-child {
+        margin-bottom: 8px;
+    }
+
+    .question-text {
+        font-size: 13px;
+        margin-bottom: 10px;
+        color: var(--vscode-foreground);
+        line-height: 1.4;
+    }
+
+    .question-options {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+    }
+
+    .question-option {
+        display: flex;
+        align-items: flex-start;
+        gap: 8px;
+        padding: 8px 12px;
+        border: 1px solid var(--vscode-panel-border);
+        border-radius: 6px;
+        cursor: pointer;
+        transition: all 0.15s ease;
+    }
+
+    .question-option:hover {
+        background-color: var(--vscode-list-hoverBackground);
+        border-color: var(--vscode-focusBorder);
+    }
+
+    .question-option.selected {
+        background-color: rgba(100, 100, 255, 0.12);
+        border-color: var(--vscode-focusBorder);
+    }
+
+    .question-option input[type="radio"],
+    .question-option input[type="checkbox"] {
+        margin-top: 3px;
+        flex-shrink: 0;
+        cursor: pointer;
+    }
+
+    .option-content {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        cursor: pointer;
+    }
+
+    .option-label {
+        font-weight: 500;
+        font-size: 13px;
+    }
+
+    .option-description {
+        font-size: 11px;
+        color: var(--vscode-descriptionForeground);
+    }
+
+    .other-text-input {
+        width: 100%;
+        padding: 6px 10px;
+        margin-top: 6px;
+        border: 1px solid var(--vscode-input-border);
+        background-color: var(--vscode-input-background);
+        color: var(--vscode-input-foreground);
+        border-radius: 4px;
+        font-size: 13px;
+        font-family: var(--vscode-font-family);
+        box-sizing: border-box;
+        display: none;
+    }
+
+    .other-text-input:focus {
+        outline: none;
+        border-color: var(--vscode-focusBorder);
+    }
+
+    .question-buttons {
+        margin-top: 12px;
+        display: flex;
+        justify-content: flex-end;
+    }
+
+    .question-buttons .btn {
+        background-color: var(--vscode-button-background);
+        color: var(--vscode-button-foreground);
+        border: none;
+        padding: 6px 16px;
+        border-radius: 4px;
+        font-size: 12px;
+        cursor: pointer;
+        transition: background-color 0.15s ease;
+    }
+
+    .question-buttons .btn:hover {
+        background-color: var(--vscode-button-hoverBackground);
+    }
+
+    .question-decision {
+        font-size: 13px;
+        font-weight: 600;
+        padding: 8px 12px;
+        text-align: center;
+        border-radius: 4px;
+        margin-top: 8px;
+    }
+
+    .question-decision.answered {
+        background-color: rgba(0, 122, 204, 0.15);
+        color: var(--vscode-charts-blue, #3794ff);
+        border: 1px solid rgba(0, 122, 204, 0.3);
+    }
+
+    .question-decision.cancelled {
+        background-color: rgba(128, 128, 128, 0.15);
+        color: var(--vscode-descriptionForeground);
+        border: 1px solid rgba(128, 128, 128, 0.3);
+    }
+
+    .question-decided {
+        opacity: 0.7;
+        pointer-events: none;
+    }
+
+    .question-decided .question-buttons {
+        display: none;
     }
 
     /* Permissions Management */


### PR DESCRIPTION
## Summary
- Fix AskUserQuestion tool showing as raw JSON permission dialog instead of interactive UI
- Fix stop button not killing Claude process on Windows (ghost processes, "Stream closed" errors)
- Add orphaned conversation recovery on startup
## Changes
- Intercept AskUserQuestion inside can_use_tool flow and render interactive question card with radio/checkbox/free-text options
- Format answers as flat map for correct serialization
- Cancel pending question requests when process ends
- Run taskkill /t before abort() to kill full process tree (prevents orphaned children on Windows)
- Close stdin gracefully before force-killing process
- Add process generation counter to ignore output from killed processes
- Guard against spawning duplicate processes
- Add stream error handlers on stdin/stdout/stderr to prevent crashes
- Scan conversations directory on startup and re-index files missing from workspaceState
- Add CSS styles for question UI (options, submit button, answered/cancelled states)